### PR TITLE
Add NewWithDB method

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -17,7 +17,7 @@ import (
 
 type Config struct {
 	DSN                       string
-	Database                  *sql.DB
+	Conn                      *sql.DB
 	SkipInitializeWithVersion bool
 	DefaultStringSize         uint
 	DisableDatetimePrecision  bool
@@ -45,8 +45,8 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	// register callbacks
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{})
 
-	if dialector.Database != nil {
-		db.ConnPool = dialector.Database
+	if dialector.Conn != nil {
+		db.ConnPool = dialector.Conn
 	} else {
 		db.ConnPool, err = sql.Open("mysql", dialector.DSN)
 	}

--- a/mysql.go
+++ b/mysql.go
@@ -17,6 +17,7 @@ import (
 
 type Config struct {
 	DSN                       string
+	Database                  *sql.DB
 	SkipInitializeWithVersion bool
 	DefaultStringSize         uint
 	DisableDatetimePrecision  bool
@@ -26,8 +27,6 @@ type Config struct {
 
 type Dialector struct {
 	*Config
-
-	db *sql.DB
 }
 
 func Open(dsn string) gorm.Dialector {
@@ -38,13 +37,6 @@ func New(config Config) gorm.Dialector {
 	return &Dialector{Config: &config}
 }
 
-func NewWithDB(db *sql.DB) gorm.Dialector {
-	return &Dialector{
-		Config: &Config{},
-		db:     db,
-	}
-}
-
 func (dialector Dialector) Name() string {
 	return "mysql"
 }
@@ -53,8 +45,8 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	// register callbacks
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{})
 
-	if dialector.db != nil {
-		db.ConnPool = dialector.db
+	if dialector.Database != nil {
+		db.ConnPool = dialector.Database
 	} else {
 		db.ConnPool, err = sql.Open("mysql", dialector.DSN)
 	}


### PR DESCRIPTION
Support this unit test with [go-sqlmock](github.com/DATA-DOG/go-sqlmock)
```go
func TestMigrate(t *testing.T) {
	var (
		assert            = assert.New(t)
		database, mock, _ = sqlmock.New()
		dialector         = mysql.New(mysql.Config{
			Database: database,
		})
	)

	defer database.Close()

	db, err := gorm.Open(dialector, &gorm.Config{})
	assert.Nil(err)

	err = TableMigrate(db)
	assert.NotNil(err)

	mock.ExpectExec("CREATE TABLE `samples` (.+)").WillReturnResult(sqlmock.NewResult(1, 1))

	err = TableMigrate(db)
	assert.Nil(err)
}
```