### PR TITLE
Use more generic ConnPool instead of *sql.DB

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -187,7 +187,7 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 	case schema.Bool:
 		return "boolean"
 	case schema.Int, schema.Uint:
-		sqlType := "int"
+		sqlType := "bigint"
 		switch {
 		case field.Size <= 8:
 			sqlType = "tinyint"
@@ -197,8 +197,6 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 			sqlType = "mediumint"
 		case field.Size <= 32:
 			sqlType = "int"
-		default:
-			sqlType = "bigint"
 		}
 
 		if field.DataType == schema.Uint {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Allows using custom ConnPool implementation, returns early errors to avoid nil panics, minor lint fix due to ineffective assignment.

### User Case Description

Makes it possible to use custom sql.DB middlewares similar to [nap](https://github.com/tsenart/nap).
Avoids panic on nil if sql.Open is not successful.