### PR TITLE
implement Migrator.ColumnTypes

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -183,13 +183,15 @@ func (m Migrator) DropConstraint(value interface{}, name string) error {
 	})
 }
 
-func (m Migrator) ColumnTypes(value interface{}) (columnTypes []Column, err error) {
-	columnTypes = make([]Column, 0)
+func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType, err error) {
+	columnTypes = make([]gorm.ColumnType, 0)
 	err = m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		currentDatabase := m.DB.Migrator().CurrentDatabase()
 		columns, err := m.DB.Raw(
 			"SELECT column_name, is_nullable, data_type, character_maximum_length, "+
 				"numeric_precision, numeric_scale "+
-				"FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA() AND table_name = ?", stmt.Table).Rows()
+				"FROM information_schema.columns WHERE table_schema = ? AND table_name = ?",
+				currentDatabase, stmt.Table).Rows()
 		if err != nil {
 			return err
 		}

--- a/migrator.go
+++ b/migrator.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"database/sql"
 	"fmt"
 
 	"gorm.io/gorm"
@@ -12,6 +13,52 @@ import (
 type Migrator struct {
 	migrator.Migrator
 	Dialector
+}
+
+type Column struct {
+	name      string
+	nullable  sql.NullString
+	datatype  string
+	maxlen    sql.NullInt64
+	precision sql.NullInt64
+	scale     sql.NullInt64
+}
+
+func (c Column) Name() string {
+	return c.name
+}
+
+func (c Column) DatabaseTypeName() string {
+	return c.datatype
+}
+
+func (c Column) Length() (length int64, ok bool) {
+	ok = c.maxlen.Valid
+	if ok {
+		length = c.maxlen.Int64
+	} else {
+		length = 0
+	}
+	return
+}
+
+func (c Column) Nullable() (nullable bool, ok bool) {
+	if c.nullable.Valid {
+		nullable, ok = c.nullable.String == "YES", true
+	} else {
+		nullable, ok = false, false
+	}
+	return
+}
+
+func (c Column) DecimalSize() (precision int64, scale int64, ok bool) {
+	ok = c.precision.Valid && c.scale.Valid
+	if ok {
+		precision, scale = c.precision.Int64, c.scale.Int64
+	} else {
+		precision, scale = 0, 0
+	}
+	return
 }
 
 func (m Migrator) FullDataTypeOf(field *schema.Field) clause.Expr {
@@ -134,4 +181,44 @@ func (m Migrator) DropConstraint(value interface{}, name string) error {
 			clause.Table{Name: stmt.Table}, clause.Column{Name: name},
 		).Error
 	})
+}
+
+func (m Migrator) ColumnTypes(value interface{}) (columnTypes []Column, err error) {
+	columnTypes = make([]Column, 0)
+	err = m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		columns, err := m.DB.Raw(
+			"SELECT column_name, is_nullable, data_type, character_maximum_length, "+
+				"numeric_precision, numeric_scale "+
+				"FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA() AND table_name = ?", stmt.Table).Rows()
+		if err != nil {
+			return err
+		}
+		defer columns.Close()
+
+		for columns.Next() {
+			var (
+				name      string
+				nullable  sql.NullString
+				datatype  string
+				maxlen    sql.NullInt64
+				precision sql.NullInt64
+				scale     sql.NullInt64
+			)
+			err = columns.Scan(&name, &nullable, &datatype, &maxlen, &precision, &scale)
+			if err != nil {
+				return err
+			}
+			columnTypes = append(columnTypes, Column{
+				name:      name,
+				nullable:  nullable,
+				datatype:  datatype,
+				maxlen:    maxlen,
+				precision: precision,
+				scale:     scale,
+			})
+		}
+
+		return err
+	})
+	return
 }

--- a/migrator.go
+++ b/migrator.go
@@ -191,33 +191,26 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 			"SELECT column_name, is_nullable, data_type, character_maximum_length, "+
 				"numeric_precision, numeric_scale "+
 				"FROM information_schema.columns WHERE table_schema = ? AND table_name = ?",
-				currentDatabase, stmt.Table).Rows()
+			currentDatabase, stmt.Table).Rows()
 		if err != nil {
 			return err
 		}
 		defer columns.Close()
 
 		for columns.Next() {
-			var (
-				name      string
-				nullable  sql.NullString
-				datatype  string
-				maxlen    sql.NullInt64
-				precision sql.NullInt64
-				scale     sql.NullInt64
+			var column Column
+			err = columns.Scan(
+				&column.name,
+				&column.nullable,
+				&column.datatype,
+				&column.maxlen,
+				&column.precision,
+				&column.scale,
 			)
-			err = columns.Scan(&name, &nullable, &datatype, &maxlen, &precision, &scale)
 			if err != nil {
 				return err
 			}
-			columnTypes = append(columnTypes, Column{
-				name:      name,
-				nullable:  nullable,
-				datatype:  datatype,
-				maxlen:    maxlen,
-				precision: precision,
-				scale:     scale,
-			})
+			columnTypes = append(columnTypes, column)
 		}
 
 		return err


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested
- [ ] Update `gorm` version in `go.mod` on next tag

### What did this pull request do?

Implement `ColumnTypes` for `mysql`.

Information for each column type is taken from the `information_schema.columns` table:

- `column_name` is the name of the column
- `is_nullable` is a (nullable) string, equal to `YES` if nullable, `NO` if `not_null`
- `data_type` is the (short) name of the type (e.g., `varchar` for `character varying`)
- `character_maximum_length` is the (nullable) max length of character columns
- `numeric_precision` is the (nullable) precision of numeric columns
- `numeric_scale` is the (nullable) scale of numeric columns

[This PR](https://github.com/go-gorm/playground/pull/183) runs the tests that broke before this change using this fork.

### User Case Description

`AutoMigrate` was not detecting `size` column changes on `mysql`, see [this issue](https://github.com/go-gorm/gorm/issues/3628).
