### PR TITLE
retrieve timestamp precision from DB

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -53,10 +53,14 @@ func (c Column) Nullable() (nullable bool, ok bool) {
 }
 
 func (c Column) DecimalSize() (precision int64, scale int64, ok bool) {
-	if ok = c.precision.Valid && c.scale.Valid; ok {
-		precision, scale = c.precision.Int64, c.scale.Int64
-	} else if ok = c.datetimeprecision.Valid; ok {
-		precision, scale = c.datetimeprecision.Int64, 0
+	if c.precision.Valid {
+		if c.scale.Valid {
+			precision, scale, ok = c.precision.Int64, c.scale.Int64, true
+		} else {
+			precision, scale, ok = c.precision.Int64, 0, true
+		}
+	} else if c.datetimeprecision.Valid {
+		precision, scale, ok = c.datetimeprecision.Int64, 0, true
 	} else {
 		precision, scale, ok = 0, 0, false
 	}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Precision for timestamps is stored in the `datetime_precision` column of `information_schema.columns`.
This PR takes the `datetime_precision` and returns it from the `DecimalPrecision` function.