### PR TITLE
Return errors in savepoint and rollbackto

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -391,11 +391,9 @@ func (dialector Dialector) getSchemaIntAndUnitType(field *schema.Field) string {
 }
 
 func (dialector Dialector) SavePoint(tx *gorm.DB, name string) error {
-	tx.Exec("SAVEPOINT " + name)
-	return nil
+	return tx.Exec("SAVEPOINT " + name).Error
 }
 
 func (dialector Dialector) RollbackTo(tx *gorm.DB, name string) error {
-	tx.Exec("ROLLBACK TO SAVEPOINT " + name)
-	return nil
+	return tx.Exec("ROLLBACK TO SAVEPOINT " + name).Error
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fixed failure to return an error to the caller when `SavePoint` or `RollbackTo` fails.

### User Case Description

For example,

```go
tx := db.Begin()

tx.Create(&User{Name: "user1"})

if err := tx.SavePoint("savepoint").Error; err != nil {
	tx.Rollback()
	panic(err)
}

tx.Create(&User{Name: "user2"})

if err := tx.RollbackTo("savepointNotExist").Error; err != nil {
	// In the unmodified state, it doesn't enter this block, but proceeds to the commit below, causing both users to be committed.
	tx.Rollback()
	panic(err)
}

tx.Commit()
```

<!-- Your use case -->
