### PR TITLE
add global variable QueryClauses

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -38,6 +38,8 @@ type Dialector struct {
 var (
 	// CreateClauses create clauses
 	CreateClauses = []string{"INSERT", "VALUES", "ON CONFLICT"}
+	// QueryClauses query clauses
+	QueryClauses = []string{}
 	// UpdateClauses update clauses
 	UpdateClauses = []string{"UPDATE", "SET", "WHERE", "ORDER BY", "LIMIT"}
 	// DeleteClauses delete clauses
@@ -86,6 +88,7 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	// register callbacks
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{
 		CreateClauses: CreateClauses,
+		QueryClauses:  QueryClauses,
 		UpdateClauses: UpdateClauses,
 		DeleteClauses: DeleteClauses,
 	})


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

add a global variable QueryClause. 
So we can add our own Clause before create a gorm.DB.

我想给 gorm 写一个解析 WINDOW 窗口函数的库。
但 mysql 并没有提供全局变量 QueryClause。
所以我不能通过修改全局变量的方式去 RegisterDefaultCallbacks。

可不可以添加这个全局变量？


### User Case Description

``` go
// add WINDOW clause
mysql.QueryClauses = []string{"SELECT", "FROM", "WHERE", "WINDOW", "GROUP BY", "ORDER BY", "LIMIT", "FOR"}
gorm.Open(mysql.Open(dsn))
```
