### PR TITLE
Switch schema for bool from boolean to tinyint

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -293,7 +293,7 @@ func (dialector Dialector) Explain(sql string, vars ...interface{}) string {
 func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 	switch field.DataType {
 	case schema.Bool:
-		return "boolean"
+		return "tinyint"
 	case schema.Int, schema.Uint:
 		return dialector.getSchemaIntAndUnitType(field)
 	case schema.Float:


### PR DESCRIPTION
Change schema for schema.Bool from boolean to tinyint to prevent schema refresh on each startup.
Example
  Datatype:  Enabled   *bool
  Executes:  ALTER TABLE `objects` MODIFY COLUMN `enabled` boolean
  On column:  | objects    | tinyint(1)          | YES  |     | NULL    |                |