### PR TITLE
Support the `AUTO_RANDOM` Field

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -173,11 +173,11 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 		}
 
 		rawColumnTypes, err := rows.ColumnTypes()
-		
+
 		if err != nil {
 			return err
 		}
-		
+
 		if err := rows.Close(); err != nil {
 			return err
 		}
@@ -224,6 +224,8 @@ func (m Migrator) ColumnTypes(value interface{}) ([]gorm.ColumnType, error) {
 
 			if strings.Contains(extraValue.String, "auto_increment") {
 				column.AutoIncrementValue = sql.NullBool{Bool: true, Valid: true}
+			} else if strings.Contains(extraValue.String, "auto_random") {
+				column.AutoRandomValue = sql.NullBool{Bool: true, Valid: true}
 			}
 
 			column.DefaultValueValue.String = strings.Trim(column.DefaultValueValue.String, "'")

--- a/mysql.go
+++ b/mysql.go
@@ -427,7 +427,10 @@ func (dialector Dialector) getSchemaIntAndUnitType(field *schema.Field) string {
 		}
 		if field.AutoIncrement {
 			sqlType += " AUTO_INCREMENT"
+		} else if field.AutoRandom {
+			sqlType += " AUTO_RANDOM"
 		}
+
 		return sqlType
 	}
 
@@ -450,6 +453,8 @@ func (dialector Dialector) getSchemaCustomType(field *schema.Field) string {
 
 	if field.AutoIncrement && !strings.Contains(strings.ToLower(sqlType), " auto_increment") {
 		sqlType += " AUTO_INCREMENT"
+	} else if field.AutoRandom && !strings.Contains(strings.ToLower(sqlType), " auto_random") {
+		sqlType += " AUTO_RANDOM"
 	}
 
 	return sqlType


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

For this issue: https://github.com/go-gorm/gorm/issues/5977
Support the `AUTO_RANDOM`.

### User Case Description

<!-- Your use case -->

If you already deploy a TiDB at `localhost:4000`. You can use this code to test.

```go
package main

import (
	"fmt"
	"gorm.io/driver/mysql"
	"gorm.io/gorm"
)

type Product struct {
	ID    uint `gorm:"primaryKey;autoRandom:true"`
	Code  string
	Price uint
}

func main() {
	db, err := gorm.Open(mysql.Open("root:@tcp(127.0.0.1:4000)/test"), &gorm.Config{})
	if err != nil {
		panic("failed to connect database")
	}

	db.AutoMigrate(&Product{})

	insertProduct := &Product{Code: "D42", Price: 100}

	db.Create(insertProduct)
	fmt.Printf("insert ID: %d, Code: %s, Prict: %d\n",
		insertProduct.ID, insertProduct.Code, insertProduct.Price)

	readProduct := &Product{}
	db.First(&readProduct, "code = ?", "D42") // find product with code D42

	fmt.Printf("read ID: %d, Code: %s, Prict: %d\n",
		readProduct.ID, readProduct.Code, readProduct.Price)
}

```