### PR TITLE
Removed UNIQUE in SQL when the field is already unique

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -51,8 +51,8 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if field := stmt.Schema.LookUpField(field); field != nil {
 			fullDataType := m.FullDataTypeOf(field)
-			if m.Dialector.DontSupportRenameColumnUnique {
-				fullDataType.SQL = strings.Replace(fullDataType.SQL, " UNIQUE ", " ", 1)
+			if m.Dialector.DontSupportRenameColumnUnique || field.Unique {
+				fullDataType.SQL = strings.Replace(fullDataType.SQL, " UNIQUE", " ", 1)
 			}
 
 			return m.DB.Exec(


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fixed https://github.com/go-gorm/gorm/issues/6224.

Removed `UNIQUE` in SQL when the field is already unique.

### User Case Description

<!-- Your use case -->

Running `AutoMigrating` multiple times on fields with `uniqueIndex` tag will not creating multiple unique indexes.
