### PR TITLE
fix: migrator for mysql 5.6

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -41,6 +41,10 @@ type Config struct {
 	DontSupportForShareClause     bool
 	DontSupportNullAsDefaultValue bool
 	DontSupportRenameColumnUnique bool
+	// As of MySQL 8.0.19, ALTER TABLE permits more general (and SQL standard) syntax
+	// for dropping and altering existing constraints of any type.
+	// see https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
+	DontSupportDropConstraint bool
 }
 
 type Dialector struct {
@@ -136,14 +140,17 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 			dialector.Config.DontSupportRenameIndex = true
 			dialector.Config.DontSupportRenameColumn = true
 			dialector.Config.DontSupportForShareClause = true
+			dialector.Config.DontSupportDropConstraint = true
 		} else if strings.HasPrefix(dialector.ServerVersion, "5.7.") {
 			dialector.Config.DontSupportRenameColumn = true
 			dialector.Config.DontSupportForShareClause = true
+			dialector.Config.DontSupportDropConstraint = true
 		} else if strings.HasPrefix(dialector.ServerVersion, "5.") {
 			dialector.Config.DisableDatetimePrecision = true
 			dialector.Config.DontSupportRenameIndex = true
 			dialector.Config.DontSupportRenameColumn = true
 			dialector.Config.DontSupportForShareClause = true
+			dialector.Config.DontSupportDropConstraint = true
 		}
 
 		if strings.Contains(dialector.ServerVersion, "TiDB") {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

fix migrator for mysql 5.6.

Add `DontSupportDropConstraint` because MySQL 5.x does not support drop constraint for any type.

And it has been tested here at https://github.com/go-gorm/gorm/pull/6822 with commit https://github.com/go-gorm/gorm/pull/6822/commits/288c065e1e26db7d363da5e3e72a6971b9e4f77c

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
