### PR TITLE
feat: Allow context to be set as configuration

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -26,6 +26,7 @@ const (
 )
 
 type Config struct {
+	Context                       context.Context
 	DriverName                    string
 	ServerVersion                 string
 	DSN                           string
@@ -125,7 +126,13 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 
 	withReturning := false
 	if !dialector.Config.SkipInitializeWithVersion {
-		err = db.ConnPool.QueryRowContext(context.Background(), "SELECT VERSION()").Scan(&dialector.ServerVersion)
+		ctx := dialector.Context
+
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		err = db.ConnPool.QueryRowContext(ctx, "SELECT VERSION()").Scan(&dialector.ServerVersion)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Currently the context of the plugin for Initialize is hardcoded causing limitations on some context wrappers for example when using AWS x-ray for tracing, since the context does not contains the xray wrapping it can't be traced.

```
2024-03-04T03:24:15Z [ERROR] Suppressing AWS X-Ray context missing panic: failed to begin subsegment named 'Unknown': segment cannot be found.
2024-03-04T03:24:15Z [ERROR] Suppressing AWS X-Ray context missing panic: failed to get segment from context since segment is nil
2024-03-04T03:24:15Z [ERROR] Suppressing AWS X-Ray context missing panic: failed to end subsegment: subsegment 'Unknown' cannot be found.
```

> At this point the gorm session transaction still not initialized so we can't actually retrieve from the session using db.Transaction.Context so the best option is really pass it manually for now.

### User Case Description

Allow to trace the query using telemetry that depends on the context.

### References

- [AWS X-ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-go-sqlclients.html)
