### PR TITLE
Fix creating unique index on non-unique field

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -109,7 +109,7 @@ func (m Migrator) MigrateColumnUnique(value interface{}, field *schema.Field, co
 					return err
 				}
 			}
-			if field.UniqueIndex != "" {
+			if field.UniqueIndex != "" && !queryTx.Migrator().HasIndex(value, field.UniqueIndex) {
 				if err := execTx.Migrator().CreateIndex(value, field.UniqueIndex); err != nil {
 					return err
 				}


### PR DESCRIPTION
### What did this pull request do?

When having a named unique index on an non-unique column, the migrator will not check, if the index already exists, resulting in `Error 1061 (42000): Duplicate key name 'index_name'`

This fix adds the check, as done in the unique column code branch of the function (line 101).

### User Case Description

Creating an index on a non-unique column, but not having a unique constraint:

```go
type Ticket struct {
  ID        uint64            `gorm:"primarykey"`
  Hashes    datatypes.JSON    `gorm:"column:hashes;uniqueIndex:uq_tickets_hashes,expression:(CAST(hashes AS CHAR(40) ARRAY))"`
}
```

On the first migration, the index is successfully being created.

On the next migration the following error is given, and no `information_schema` check is being performed:

```
error="Error 1061 (42000): Duplicate key name 'uq_tickets_hashes'" sql="CREATE UNIQUE INDEX `uq_tickets_hashes` ON `tickets__simple`((CAST(hashes AS CHAR(40) ARRAY)))"
    parser.go:150: failed to migrate database: failed to migrate tickets table: Error 1061 (42000): Duplicate key name 'uq_tickets_hashes'
```

After the fix, the check is being performed:

```
sql="SELECT count(*) FROM information_schema.statistics WHERE table_schema = 'unittest' AND table_name = 'tickets__simple' AND index_name = 'uq_tickets_hashes'"
```
