### PR TITLE
feat: support generated (computed) columns via the `generated` tag

### DIFF
--- a/generated_test.go
+++ b/generated_test.go
@@ -1,0 +1,56 @@
+package mysql
+
+import (
+	"testing"
+
+	"gorm.io/gorm/schema"
+)
+
+func TestDataTypeOfGeneratedColumn(t *testing.T) {
+	dialector := Dialector{Config: &Config{}}
+	tests := []struct {
+		name  string
+		field *schema.Field
+		want  string
+	}{
+		{
+			name:  "computed column renders a STORED generated column",
+			field: &schema.Field{DataType: "decimal(12,2)", TagSettings: map[string]string{"GENERATED": "price * quantity"}},
+			want:  "decimal(12,2) GENERATED ALWAYS AS (price * quantity) STORED",
+		},
+		{
+			name:  "computed expression keeps commas",
+			field: &schema.Field{DataType: "varchar(64)", TagSettings: map[string]string{"GENERATED": "concat(first_name, last_name)"}},
+			want:  "varchar(64) GENERATED ALWAYS AS (concat(first_name, last_name)) STORED",
+		},
+		{
+			// `identity` is reserved for identity columns, which MySQL renders
+			// through its native AUTO_INCREMENT rather than a computed column.
+			name:  "identity keyword is not treated as a computed column",
+			field: &schema.Field{DataType: schema.Int, Size: 64, AutoIncrement: true, TagSettings: map[string]string{"GENERATED": "identity"}},
+			want:  "bigint AUTO_INCREMENT",
+		},
+		{
+			name:  "identity with an explicit mode is also reserved",
+			field: &schema.Field{DataType: schema.Int, Size: 64, AutoIncrement: true, TagSettings: map[string]string{"GENERATED": "identity always"}},
+			want:  "bigint AUTO_INCREMENT",
+		},
+		{
+			name:  "a bare generated tag is ignored",
+			field: &schema.Field{DataType: "decimal(10,2)", TagSettings: map[string]string{"GENERATED": "GENERATED"}},
+			want:  "decimal(10,2)",
+		},
+		{
+			name:  "a lowercase generated expression is not mistaken for a bare tag",
+			field: &schema.Field{DataType: "decimal(10,2)", TagSettings: map[string]string{"GENERATED": "generated"}},
+			want:  "decimal(10,2) GENERATED ALWAYS AS (generated) STORED",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dialector.DataTypeOf(tt.field); got != tt.want {
+				t.Errorf("DataTypeOf() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/mysql.go
+++ b/mysql.go
@@ -358,6 +358,18 @@ func (dialector Dialector) Explain(sql string, vars ...interface{}) string {
 }
 
 func (dialector Dialector) DataTypeOf(field *schema.Field) string {
+	// Computed (generated) column. MySQL/MariaDB support STORED generated
+	// columns; the expression is carried by the `generated` tag, separate from
+	// the column type.
+	// https://dev.mysql.com/doc/refman/8.0/en/create-table-generated-columns.html
+	if expr, ok := generatedColumnExpr(field); ok {
+		return dialector.dataTypeOf(field) + " GENERATED ALWAYS AS (" + expr + ") STORED"
+	}
+
+	return dialector.dataTypeOf(field)
+}
+
+func (dialector Dialector) dataTypeOf(field *schema.Field) string {
 	switch field.DataType {
 	case schema.Bool:
 		return "boolean"
@@ -539,4 +551,41 @@ func checkVersion(newVersion, oldVersion string) bool {
 	}
 
 	return false
+}
+
+// generatedColumnExpr returns the expression of a computed (generated) column
+// declared via the `generated` tag, if any. The `identity` keyword is reserved
+// for identity columns (rendered through the dialect's native auto-increment)
+// and is not a computed-column expression.
+func generatedColumnExpr(field *schema.Field) (string, bool) {
+	value, ok := field.TagSettings["GENERATED"]
+	if !ok {
+		return "", false
+	}
+	// Ignore an empty value or a bare `generated` tag, which the tag parser
+	// stores as the upper-cased key, rather than treating it as an expression.
+	if value = strings.TrimSpace(value); value == "" || value == "GENERATED" {
+		return "", false
+	}
+	if isIdentityKeyword(value) {
+		return "", false
+	}
+	return value, true
+}
+
+// isIdentityKeyword reports whether value is the `identity` keyword, optionally
+// combined with the generation mode `always` / `by default`. Any other token
+// means value is a computed-column expression.
+func isIdentityKeyword(value string) bool {
+	identity := false
+	for _, token := range strings.Fields(strings.ToLower(value)) {
+		switch token {
+		case "identity":
+			identity = true
+		case "always", "by", "default":
+		default:
+			return false
+		}
+	}
+	return identity
 }


### PR DESCRIPTION
## What this adds

Support for **MySQL / MariaDB STORED generated columns** through the `generated` struct tag, keeping the generation expression separate from the column type. Part of rounding out generated-column support across the GORM drivers (see go-gorm/postgres#345 and go-gorm/sqlite#230). Relates to go-gorm/gorm#7191.

```go
type Product struct {
    ID       uint    `gorm:"primaryKey"`
    Price    float64 `gorm:"type:decimal(10,2)"`
    Quantity int
    Total    float64 `gorm:"->;type:decimal(12,2);generated:price * quantity"` // decimal(12,2) GENERATED ALWAYS AS (price * quantity) STORED
}
```

- The `generated` value is taken **verbatim** as the expression of a `STORED` [generated column](https://dev.mysql.com/doc/refman/8.0/en/create-table-generated-columns.html). Commas inside the expression are preserved, so `generated:concat(a, b)` works.
- Combine with `->` so GORM treats the column as read-only (MySQL forbids writing generated columns).
- The `identity` keyword is reserved for identity columns; MySQL has no SQL-standard identity, so `generated:identity` is left to the existing `AUTO_INCREMENT` handling rather than being mistaken for an expression.

## Implementation

`DataTypeOf` appends the `GENERATED ALWAYS AS (...) STORED` clause when a computed expression is present; the base column type is computed exactly as before.

## Tests & verification

- Unit test `TestDataTypeOfGeneratedColumn` covers the computed clause, comma-safe expressions, and the reserved `identity` keyword.
- Verified end-to-end against a real MySQL 8 instance: `CREATE TABLE` emits the `STORED` generated column, `INSERT` omits it, the read-back value is correct, and repeated `AutoMigrate` runs are idempotent.

```sql
CREATE TABLE `products` (`id` bigint unsigned AUTO_INCREMENT,`name` varchar(64),`price` decimal(10,2),
  `quantity` bigint,`total` decimal(12,2) GENERATED ALWAYS AS (price * quantity) STORED,PRIMARY KEY (`id`))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)